### PR TITLE
Cleanup the action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
           ./compile.sh -t linux64 -j 4 -f -g
           tar -czf PHP_Linux.tar.gz bin
       - name: Create and Publish Release
+        if: steps.build-cache.outputs.cache-hit != 'true'
         uses: marvinpinto/action-automatic-releases@v1.1.1
         with:
           automatic_release_tag: "${{ matrix.php }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,25 +11,25 @@ jobs:
         php: ["7.4.16"]
     steps:
       - uses: actions/checkout@v2
-      - run: chmod +x compile.sh
-      - run: export CFLAGS="$CFLAGS -march=x86-64"
-      - run: export CXXFLAGS="$CXXFLAGS -march=x86-64"
       - name: Cache Check
         id: build-cache
         uses: actions/cache@v2
         with:
           path: "./bin"
           key: "build-generic-linux-${{ matrix.php }}-${{ hashFiles('./compile.sh') }}"
-      - name: Update APT
-        if: steps.build-cache.outputs.cache-hit != 'true'
-        run: sudo apt update
       - name: Install dependencies via APT
         if: steps.build-cache.outputs.cache-hit != 'true'
-        run: sudo apt install re2c libtool libtool-bin g++ git bison wget gzip make autoconf automake libc-bin bzip2 cmake pkg-config zip
+        run: |
+          sudo apt update
+          sudo apt install -y re2c libtool libtool-bin g++ git bison wget gzip make autoconf automake libc-bin bzip2 cmake pkg-config zip
       - name: Compile
         if: steps.build-cache.outputs.cache-hit != 'true'
-        run: ./compile.sh -t linux64 -j 4 -f -g
-      - run: tar -czf PHP_Linux.tar.gz bin
+        run: |
+          chmod +x compile.sh
+          export CFLAGS="$CFLAGS -march=x86-64"
+          export CXXFLAGS="$CXXFLAGS -march=x86-64"
+          ./compile.sh -t linux64 -j 4 -f -g
+          tar -czf PHP_Linux.tar.gz bin
       - name: Create and Publish Release
         uses: marvinpinto/action-automatic-releases@v1.1.1
         with:
@@ -38,4 +38,3 @@ jobs:
           title: "PHP ${{ matrix.php }} for Linux"
           files: PHP_Linux.tar.gz
           prerelease: false
-        


### PR DESCRIPTION
This PR cleans up the action, rather than duplicating runs, it now properly install everything in the right batches.
APT is its own batch of commands, then the compile script is its own batch of commands.